### PR TITLE
Fix i18n translation bugs - homepage mixed language & hardcoded text

### DIFF
--- a/apps/customer/src/app/[locale]/page.tsx
+++ b/apps/customer/src/app/[locale]/page.tsx
@@ -49,7 +49,7 @@ export default function HomePage() {
       <div className="flex justify-center py-3">
         <span className="inline-flex items-center gap-2 rounded-full px-5 py-1.5 text-xs font-semibold text-white" style={{ background: 'linear-gradient(135deg, #E8837C, #D4A28A)' }}>
           <Sparkles className="h-3.5 w-3.5" />
-          NEW ARRIVAL — ชุดใหม่ประจำสัปดาห์
+          {t('home.banner')}
         </span>
       </div>
 
@@ -73,7 +73,7 @@ export default function HomePage() {
                 keep the budget.
               </h1>
               <p className="font-sans-thai text-lg md:text-xl text-cb-secondary mb-8 max-w-lg">
-                เช่าชุดสวย ในราคาที่คุณเอื้อมถึง — ชุดแบรนด์เนมพรีเมียม จัดส่งถึงบ้าน คืนง่าย ไม่ยุ่งยาก
+                {t('home.hero.subtitle')} — ชุดแบรนด์เนมพรีเมียม จัดส่งถึงบ้าน คืนง่าย ไม่ยุ่งยาก
               </p>
               <div className="flex flex-col sm:flex-row gap-3 justify-center md:justify-start">
                 <Link
@@ -114,10 +114,10 @@ export default function HomePage() {
               {/* Floating price overlay */}
               {(popularProducts[0] || newProducts[0]) && (
                 <div className="absolute -bottom-3 -right-2 bg-white rounded-xl shadow-md px-4 py-2.5 z-10">
-                  <p className="text-[10px] font-medium text-cb-secondary uppercase tracking-wider">ชุดแนะนำ</p>
+                  <p className="text-[10px] font-medium text-cb-secondary uppercase tracking-wider">{t('home.recommended')}</p>
                   <p className="text-sm font-bold text-cb-heading">
                     + ฿{((popularProducts[0] || newProducts[0])?.rental_prices?.['1day'] ?? 0).toLocaleString()}
-                    <span className="text-xs font-normal text-cb-secondary"> /วัน</span>
+                    <span className="text-xs font-normal text-cb-secondary"> {t('home.perDay')}</span>
                   </p>
                 </div>
               )}

--- a/apps/customer/src/messages/en.json
+++ b/apps/customer/src/messages/en.json
@@ -18,8 +18,8 @@
   },
   "home": {
     "hero": {
-      "title": "Rent Beautiful Dresses",
-      "subtitle": "Premium dress rental for every occasion",
+      "title": "Wear the dream dress, keep the budget.",
+      "subtitle": "Rent beautiful dresses at affordable prices — premium brand dresses, delivered to your door, easy returns",
       "cta": "Start Renting",
       "ctaFeatured": "View Featured"
     },
@@ -40,6 +40,10 @@
     "newArrivals": {
       "title": "Just arrived"
     },
+        "banner": "NEW ARRIVAL — New dresses this week",
+        "recommended": "Recommended",
+        "perDay": "/day",
+        "newBadge": "NEW",
     "profile": {
       "title": "Your Profile",
       "subtitle": "Manage your profile and shipping addresses",

--- a/apps/customer/src/messages/th.json
+++ b/apps/customer/src/messages/th.json
@@ -35,11 +35,15 @@
       "fastDelivery": "จัดส่งด่วน 24h"
     },
     "popular": {
-      "title": "ชุดยอดนิยม this week"
+      "title": "ชุดยอดนิยมประจำสัปดาห์"
     },
     "newArrivals": {
-      "title": "เพิ่งเข้าใหม่ just arrived"
+      "title": "เพิ่งเข้าใหม่d"
     },
+        "banner": "NEW ARRIVAL — ชุดใหม่ประจำสัปดาห์",
+        "recommended": "ชุดแนะนำ",
+        "perDay": "/วัน",
+        "newBadge": "ใหม่",
     "profile": {
       "title": "ข้อมูลส่วนตัว",
       "subtitle": "จัดการโปรไฟล์และที่อยู่จัดส่งของคุณ",


### PR DESCRIPTION
## Changes
- Fix TH homepage section headings: removed English from Thai text
- Replace hardcoded banner text with t('home.banner')
- Replace hardcoded recommended/perDay text with t() calls
- Add new translation keys: banner, recommended, perDay, newBadge
- Update EN hero title and subtitle translations

## Remaining (needs follow-up PR)
- Hero heading still hardcoded (multiline JSX)
- Hero subtitle still hardcoded (multiline JSX)
- Duplicate footer removal
- Language switcher
- Product detail '1 days' grammar fix