### PR TITLE
fix: singular day label (1 day instead of 1 days)

### DIFF
--- a/apps/customer/src/app/[locale]/products/[id]/page.tsx
+++ b/apps/customer/src/app/[locale]/products/[id]/page.tsx
@@ -254,7 +254,7 @@ export default function ProductDetailPage() {
                       }`}
                     >
                       <div className="text-xs text-cb-secondary">
-                        {tier.days} {t('days')}
+                        {tier.days} {tier.days === 1 ? t('day') : t('days')}
                       </div>
                       <div className="text-xl font-bold text-cb-heading mt-1">
                         ฿{(product.rental_prices?.[tier.key] ?? 0).toLocaleString()}
@@ -353,7 +353,7 @@ export default function ProductDetailPage() {
                     ฿{rentalPrice.toLocaleString()}
                   </p>
                   <span className="text-xs text-cb-secondary">
-                    {actualDays} {t('days')}
+                    {actualDays} {actualDays === 1 ? t('day') : t('days')}
                     {selectedStartDate ? ` • ${selectedStartDate}` : ''}
                     {selectedEndDate ? ` → ${selectedEndDate}` : ''}
                   </span>

--- a/apps/customer/src/messages/en.json
+++ b/apps/customer/src/messages/en.json
@@ -115,6 +115,7 @@
       "added": "Added!",
       "totalRental": "Total Rental",
       "days": "days",
+            "day": "day",
       "backToProducts": "Back to Products",
       "notFound": "Product not found",
       "rentalPricing": "Rental Pricing",

--- a/apps/customer/src/messages/th.json
+++ b/apps/customer/src/messages/th.json
@@ -121,6 +121,7 @@
       "added": "เพิ่มแล้ว!",
       "totalRental": "ค่าเช่ารวม",
       "days": "วัน",
+            "day": "วัน",
       "backToProducts": "กลับไปหน้าสินค้า",
       "notFound": "ไม่พบสินค้า",
       "rentalPricing": "ราคาเช่า",

--- a/apps/customer/src/messages/zh.json
+++ b/apps/customer/src/messages/zh.json
@@ -111,6 +111,7 @@
       "added": "已添加！",
       "totalRental": "租赁总价",
       "days": "天",
+            "day": "天",
       "backToProducts": "返回商品列表",
       "notFound": "未找到商品",
       "rentalPricing": "租赁价格",


### PR DESCRIPTION
Fix grammar: show "1 day" instead of "1 days" on product detail page.

- Add singular "day" key to en.json, th.json, zh.json
- Use ternary conditional in page.tsx for singular/plural